### PR TITLE
Normalize room names when referencing storage

### DIFF
--- a/src/components/organisms/GameTable/GameTable.tsx
+++ b/src/components/organisms/GameTable/GameTable.tsx
@@ -72,7 +72,7 @@ const GameTable: React.FC<GameTableProps> = ({
     setRevealed(false);
     localStorage.setItem('revealed', 'false');
 
-    const roomName = localStorage.getItem('salaActual') || 'default';
+    const roomName = (localStorage.getItem('salaActual') || 'default').toLowerCase();
     const raw = localStorage.getItem(`room:${roomName}:players`);
     if (raw) {
       const players = JSON.parse(raw);

--- a/src/components/organisms/ModalUserSettings/ModalUserSettings.tsx
+++ b/src/components/organisms/ModalUserSettings/ModalUserSettings.tsx
@@ -52,7 +52,7 @@ const ModalUserSettings: React.FC<ModalUserSettingsProps> = ({
     const { name } = getCurrentSessionPlayer();
     setCurrentName(name);
 
-    const roomName = localStorage.getItem('salaActual') || 'default';
+    const roomName = (localStorage.getItem('salaActual') || 'default').toLowerCase();
     const raw = localStorage.getItem(`room:${roomName}:players`);
     if (raw) {
       const parsedPlayers: Player[] = JSON.parse(raw);
@@ -71,13 +71,13 @@ const ModalUserSettings: React.FC<ModalUserSettingsProps> = ({
   }, []);
 
   useEffect(() => {
-    const room = localStorage.getItem('salaActual') || 'default';
+    const room = (localStorage.getItem('salaActual') || 'default').toLowerCase();
     const raw = localStorage.getItem(`room:${room}:cards`);
     setCards(raw ? JSON.parse(raw) : [0, 1, 3, 5, 8, 13, 21, 34, 55, 89, '?', '☕']);
   }, []);
 
   const handleSave = () => {
-  const roomName = localStorage.getItem('salaActual');
+  const roomName = (localStorage.getItem('salaActual') || 'default').toLowerCase();
   if (!roomName) return;
 
   const raw = localStorage.getItem(`room:${roomName}:players`);

--- a/src/components/pages/SalaPage.tsx
+++ b/src/components/pages/SalaPage.tsx
@@ -56,12 +56,12 @@ const SalaPage = () => {
 
   useEffect(() => {
     if (roomName) {
-      const currentRoom = localStorage.getItem('salaActual');
+      const currentRoom = localStorage.getItem('salaActual')?.toLowerCase();
 
-      if (!currentRoom || currentRoom !== roomName) {
-        localStorage.setItem('salaActual', roomName);
+      if (!currentRoom || currentRoom !== finalRoomName) {
+        localStorage.setItem('salaActual', finalRoomName);
 
-        const playersKey = `room:${roomName}:players`;
+        const playersKey = `room:${finalRoomName}:players`;
         const existingPlayers = localStorage.getItem(playersKey);
 
         if (!existingPlayers) {
@@ -208,14 +208,14 @@ useEffect(() => {
   const [cards, setCards] = useState<(string | number)[]>([]);
 
   useEffect(() => {
-    const room = localStorage.getItem("salaActual") || "default";
+    const room = (localStorage.getItem("salaActual") || "default").toLowerCase();
     const raw = localStorage.getItem(`room:${room}:cards`);
     setCards(raw ? JSON.parse(raw) : [0, 1, 3, 5, 8, 13, 21, 34, 55, 89, "?", "☕"]);
   }, []);
 
   useEffect(() => {
     const handleCardsUpdated = () => {
-      const room = localStorage.getItem("salaActual") || "default";
+      const room = (localStorage.getItem("salaActual") || "default").toLowerCase();
       const raw = localStorage.getItem(`room:${room}:cards`);
       setCards(raw ? JSON.parse(raw) : []);
     };


### PR DESCRIPTION
## Summary
- normalize salaActual before constructing storage keys in ModalUserSettings
- normalize salaActual before constructing storage keys in GameTable
- store normalized room names in SalaPage and normalize when reading cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6867152ce36883289185ecb9e527613c